### PR TITLE
Replace inet_addr() with inet_pton() for IP conversion

### DIFF
--- a/http_tcpServer_linux.cpp
+++ b/http_tcpServer_linux.cpp
@@ -30,7 +30,7 @@ namespace http
     {
         m_socketAddress.sin_family = AF_INET;
         m_socketAddress.sin_port = htons(m_port);
-        m_socketAddress.sin_addr.s_addr = inet_addr(m_ip_address.c_str());
+        inet_pton(AF_INET, m_ip_address.c_str(), &(m_socketAddress.sin_addr));
 
         if (startServer() != 0)
         {

--- a/http_tcpserver.cpp
+++ b/http_tcpserver.cpp
@@ -30,7 +30,7 @@ namespace http
     {
         m_socketAddress.sin_family = AF_INET;
         m_socketAddress.sin_port = htons(m_port);
-        m_socketAddress.sin_addr.s_addr = inet_addr(m_ip_address.c_str());
+        inet_pton(AF_INET, m_ip_address.c_str(), &(m_socketAddress.sin_addr));
 
         if (startServer() != 0)
         {


### PR DESCRIPTION
Replaced the `inet_addr()` function with `inet_pton()`, as `inet_addr()` is deprecated and lacks proper error handling. `inet_pton()` is a better choice since it supports both IPv4 and IPv6, and provides improved validation and error handling.